### PR TITLE
#ModelMaker #OD: `gen_dataset` should by default use is_training=Fals…

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/data_util/object_detector_dataloader.py
+++ b/tensorflow_examples/lite/model_maker/core/data_util/object_detector_dataloader.py
@@ -338,7 +338,7 @@ class DataLoader(dataloader.DataLoader):
   def gen_dataset(self,
                   model_spec,
                   batch_size=None,
-                  is_training=True,
+                  is_training=False,
                   use_fake_data=False):
     """Generate a batched tf.data.Dataset for training/evaluation.
 


### PR DESCRIPTION
…e to align with other tasks.

PiperOrigin-RevId: 375832138